### PR TITLE
Fixes some issues with fw loading

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1527,6 +1527,7 @@ vendor/lib64/libwvhidl.so
 vendor/bin/cnss-daemon
 vendor/bin/lowirpcd
 vendor/firmware/wlanmdsp.otaupdate
+vendor/firmware/wlan/qca_cld/wlan_mac.bin
 
 # Wi-Fi Display
 vendor/bin/wfdhdcphalservice


### PR DESCRIPTION
[  300.886236] ueventd: firmware: attempted /etc/firmware/wlan/qca_cld/wlan_mac.bin, open failed: No such file or directory
[  300.886258] ueventd: firmware: attempted /odm/firmware/wlan/qca_cld/wlan_mac.bin, open failed: No such file or directory
[  300.886278] ueventd: firmware: attempted /vendor/firmware/wlan/qca_cld/wlan_mac.bin, open failed: No such file or directory
[  300.886297] ueventd: firmware: attempted /firmware/image/wlan/qca_cld/wlan_mac.bin, open failed: No such file or directory
[  300.886316] ueventd: firmware: attempted /vendor/firmware_mnt/image/wlan/qca_cld/wlan_mac.bin, open failed: No such file or directory
[  300.886336] ueventd: firmware: attempted /mnt/vendor/persist/wlan/qca_cld/wlan_mac.bin, open failed: No such file or directory